### PR TITLE
ci: GitHub Actionsへsafe-chain導入

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,9 @@ jobs:
           node -v
           npm -v
 
+      - name: Install safe-chain
+        run: curl -fsSL https://github.com/AikidoSec/safe-chain/releases/latest/download/install-safe-chain.sh | sh -s -- --ci
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## 概要
- `Deploy GitHub Pages` ワークフローに safe-chain インストール手順を追加しました。
- `npm ci` 実行前に `AikidoSec/safe-chain` のインストールスクリプトを実行する構成です。

## 変更内容
- `.github/workflows/pages.yml`
  - `Install safe-chain` ステップを `Install dependencies (npm ci)` の直前に追加

## 確認項目
- 変更範囲が GitHub Actions ワークフローのみであること
- 依存ライブラリのバージョン更新を含まないこと

## 備考
- 既存の `npm ci` / `npm run build` は分離済みのため、コマンド分割は不要でした。
