### PR TITLE
ReactとReact DOMを19.2.5へ更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "i18next": "^25.4.0",
         "motion": "^12.23.12",
-        "react": "^19.1.1",
-        "react-dom": "^19.1.1",
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5",
         "react-i18next": "^15.7.1",
         "react-rewards": "^2.1.0",
         "use-timer": "^2.0.1"
@@ -2616,24 +2616,24 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-i18next": {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "i18next": "^25.4.0",
     "motion": "^12.23.12",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "react-i18next": "^15.7.1",
     "react-rewards": "^2.1.0",
     "use-timer": "^2.0.1"


### PR DESCRIPTION
## 概要
- `react` を `^19.1.1` から `^19.2.5` へ更新しました。
- `react-dom` を `^19.1.1` から `^19.2.5` へ更新しました。
- `package-lock.json` を更新しました。

## 補足
- `powpow_reversi` では TypeScript 6 系のメジャー更新も確認しましたが、`i18next` / `react-i18next` との peer dependency 条件があり、今回は見送りました。
- そのため、今回は安全に適用できる React 系のパッチ更新を先に取り込みます。

## 検証
- `npm test`
  - `test` スクリプト未定義のため、テストコードなしとして扱いました。
- `npm run lint`
  - 成功（既存の warning 5 件のみ）
- `npm run build`
  - 成功
