### PR TITLE
chore: GitHub Actions を Node 24 系ランタイムへ更新

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
         run: npm run build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 概要
- GitHub Pages workflow で使っている GitHub Actions を Node 24 系ランタイムの版へ更新
- `actions/checkout` を `v4` から `v5` へ更新
- `actions/setup-node` を `v4` から `v5` へ更新
- `actions/upload-pages-artifact` を `v3` から `v5` へ更新
- `actions/deploy-pages` を `v4` から `v5` へ更新

## 確認
- `npm run lint`（warning 5件・error 0件）
- `npm run build`
