### PR TITLE
Group Dependabot updates into a weekly multi-ecosystem group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,30 @@
 version: 2
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    patterns:
+      - "*"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns:
+      - "*"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- Reduce noise by consolidating Dependabot PRs across ecosystems into a single weekly group. 
- Include GitHub Actions updates so action and npm updates can be grouped together when possible. 
- Ensure security updates are also grouped while keeping the existing npm cooldown behavior.

### Description
- Add `multi-ecosystem-groups.dependency-updates` with a weekly schedule to `.github/dependabot.yml`.
- Add `patterns: ["*"]` and `multi-ecosystem-group: "dependency-updates"` to the `npm` and new `github-actions` entries to allow grouping.
- Add wildcard security groups `all-npm-security-updates` and `all-github-actions-security-updates` that use `applies-to: "security-updates"`.
- Preserve the existing `cooldown.default-days: 2` for the `npm` update configuration.

### Testing
- Validated the YAML structure and expected keys with `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"].is_a?(Hash); abort("missing dependency-updates") unless data.dig("multi-ecosystem-groups", "dependency-updates", "schedule", "interval") == "weekly"; abort("bad updates") unless data["updates"].is_a?(Array) && data["updates"].size == 2; abort("missing patterns") unless data["updates"].all? { |u| u["patterns"] == ["*"] && u["multi-ecosystem-group"] == "dependency-updates" }; puts "dependabot.yml is valid YAML"'`, which succeeded. 
- Ran `git diff --check` to detect whitespace issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b8a923b08326874d1fae0e991155)