### PR TITLE
Dependabot設定を更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,33 @@
 version: 2
-multi-ecosystem-groups:
-  dependency-updates:
-    schedule:
-      interval: "weekly"
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
-    patterns:
-      - "*"
     cooldown:
-      default-days: 2
+      default-days: 7
+      semver-major-days: 60
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-npm-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    multi-ecosystem-group: "dependency-updates"
   - package-ecosystem: "github-actions"
     directory: "/"
-    patterns:
-      - "*"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     groups:
       all-github-actions-security-updates:
         applies-to: "security-updates"
         patterns:
           - "*"
-    multi-ecosystem-group: "dependency-updates"


### PR DESCRIPTION
### Motivation
- 参考リポジトリに合わせてDependabot設定を整理し、通常のminor/patch更新ノイズを減らしてセキュリティ更新を優先するためです。 
- npmとGitHub Actionsのチェックを週次に統一し、クールダウンやメジャー更新の扱いを明確にするためです。

### Description
- `.github/dependabot.yml` を編集し、`npm` のスケジュールを週次に設定し `cooldown.default-days` を `7`、`cooldown.semver-major-days` を `60` に変更しました。 
- すべての通常の `version-update:semver-minor` と `version-update:semver-patch` を `ignore` に追加して通常更新を抑制し、セキュリティ更新をグループ化しました。 
- `github-actions` についても週次チェックと同様の `ignore` 設定を追加してセキュリティ更新のみをまとめるようにしました。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort "invalid version" unless data["version"] == 2; abort "invalid updates" unless data["updates"].is_a?(Array) && data["updates"].size == 2; puts "dependabot.yml parsed successfully"'` は成功しました。 
- `git diff --check` は問題ありませんでした。 
- `python` を使った `yaml.safe_load` の簡易チェックは `PyYAML` 未インストールのため実行できませんでした（`PyYAML is not installed`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b21f09e288326b788589a728bb885)